### PR TITLE
Add Composer installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,32 @@ zmq-phpdoc
 ==========
 
 Helper autocomplete for php zmq extension
+
+## Installation
+
+With composer, just require the file `zmq.php` by:
+
+- Adding the file as a repository in `"repositories"` block,
+- and adding the repository as a dev dependency in `"require-dev"` block:
+
+``` js
+    "require-dev": {
+        "ekho/zmq-phpdoc": "1.0"
+    },
+    
+    { '...' },
+    
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "ekho/zmq-phpdoc",
+                "version": "1.0",
+                "dist": {
+                    "url": "https://raw.githubusercontent.com/ekho/zmq-phpdoc/master/zmq.php",
+                    "type": "file"
+                }
+            }
+        }
+    ]
+```


### PR DESCRIPTION
As the project is not registered in Packagist, we can also require only the `zmq.php` file.
This PR add instructions in Readme to say how to do this.
